### PR TITLE
Use comparison in successful method

### DIFF
--- a/lib/Test/Harness.pm
+++ b/lib/Test/Harness.pm
@@ -63,6 +63,6 @@ class Test::Harness::File {
     }
 
     method successful {
-        $.tests-planned = $.tests-passed
+        $.tests-planned == $.tests-passed
     }
 }


### PR DESCRIPTION
Currently, this method uses assignment, which causes it to always pass as long it passed at least one test. This pull request fixes it.
