### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/file.t
+++ b/t/file.t
@@ -6,7 +6,7 @@ plan 40;
 my $h = Test::Harness::File.new;
 $h.line('1..1');
 is $h.tests-planned, 1, 'plan parsed correctly';
-dies_ok { $h.line('1..30') }, 'can only plan once';
+dies-ok { $h.line('1..30') }, 'can only plan once';
 
 $h.line('ok');
 diag 'testing bare ok';
@@ -28,7 +28,7 @@ is $h.successful, False, 'it went okay... NOT';
 
 diag 'garbage input';
 $h = Test::Harness::File.new;
-lives_ok {
+lives-ok {
     $h.line('# I am a comment');
     $h.line('foo baz');
     $h.line('notok');
@@ -40,11 +40,11 @@ is $h.todos, 0;
 
 diag 'wrong test number';
 $h = Test::Harness::File.new;
-dies_ok { $h.line('ok 7') }
+dies-ok { $h.line('ok 7') }
 
 diag 'basic legitimate input';
 $h = Test::Harness::File.new;
-lives_ok {
+lives-ok {
     $h.line('ok 1');
     $h.line('not ok 2');
     $h.line('ok 3 - test description');
@@ -59,7 +59,7 @@ is $h.successful, False, 'it went okay... NOT';
 
 diag 'todoed tests';
 $h = Test::Harness::File.new;
-lives_ok {
+lives-ok {
     $h.line('ok 1 # TODO');
     $h.line('ok 2 # TODO foo');
     $h.line('not ok 3 # ToDO');
@@ -74,7 +74,7 @@ is $h.successful, True, 'it went okay';
 
 diag 'skipped tests';
 $h = Test::Harness::File.new;
-lives_ok {
+lives-ok {
     $h.line('ok 1 # SKIP');
     $h.line('ok 2 # SKIP foo');
     $h.line('not ok 3 # skip');
@@ -88,10 +88,10 @@ is $h.todos-passed, 0;
 is $h.tests-skipped, 4;
 is $h.successful, True, 'it went okay';
 
-dies_ok { $h.line('ok foo bar #dupa') }, 'malformed TAP';
+dies-ok { $h.line('ok foo bar #dupa') }, 'malformed TAP';
 
 $h = Test::Harness::File.new;
-lives_ok {
+lives-ok {
     $h.line('1..1');
     $h.line("ok 1 - JSON string «{}» parsed")
 }, 'does not fail on funny characters';


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.